### PR TITLE
Separate the blocks of text

### DIFF
--- a/PdfSharpTextExtractor.cs
+++ b/PdfSharpTextExtractor.cs
@@ -364,7 +364,11 @@ namespace PdfSharpTextExtractor
         }
         private void ExtractText(COperator obj, StringBuilder target)
         {
-
+            if (obj.OpCode.OpCodeName == OpCodeName.ET)
+            {
+                target.Append('\n');
+            }
+            else
             if (obj.OpCode.OpCodeName == OpCodeName.QuoteSingle || obj.OpCode.OpCodeName == OpCodeName.QuoteDbl || obj.OpCode.OpCodeName == OpCodeName.Tj || obj.OpCode.OpCodeName == OpCodeName.TJ)
             {
                 if (obj.OpCode.OpCodeName == OpCodeName.QuoteSingle || obj.OpCode.OpCodeName == OpCodeName.QuoteDbl) target.Append("\n");


### PR DESCRIPTION
Treat each BT/ET block as a separate one. Normally they separate far-away text, but previously the extractor merged those.